### PR TITLE
Add materials page with a basic layout

### DIFF
--- a/app/routes/Materials.tsx
+++ b/app/routes/Materials.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Materials() {
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1>Materials Page</h1>
+      <p>This is where users will find their painting materials list.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
created a new route at /Materials since we're using file based routing
this page is going to have all the materials that the users will own and allow them to add one as well
right now this page just has placeholder content and a basicc layout